### PR TITLE
Removed Landlord as a registration option

### DIFF
--- a/pages/signup/profileSelect.tsx
+++ b/pages/signup/profileSelect.tsx
@@ -15,7 +15,7 @@ export default function Index() {
         setState,
     ] = useState([
         undefined,
-        false
+        true
     ]);
     useEffect(() => {
         if (!router.isReady) {
@@ -89,9 +89,9 @@ export default function Index() {
             <div className="flex flex-col p-6 gap-4">
                 <Logo src="../../assets/images/Turnkey_logo_colour.png"></Logo>
 
-                <p className="align-left tk-text-blue">Are you a renter or a landlord?</p>
+                {/* <p className="align-left tk-text-blue">Are you a renter or a landlord?</p> */}
                 {/* Hold id values and update the state */}
-                <Toggle
+                {/* <Toggle
                     labelFalse="Landlord"
                     labelTrue="Renter"
                     handleChange={($event) =>
@@ -101,10 +101,10 @@ export default function Index() {
                         ])
                     }
                     value={userType}
-                />
+                /> */}
 
                 <Button variant="secondary" handleClick={() => procede()}>
-                    Next
+                    Make Renter Profile
                 </Button>
             </div>
         </div>)


### PR DESCRIPTION
# Description
- Removed the Toggle to select Renter or Landlord
- Set Renter to be the default profile
- Kept the page to make it easy to add back the toggle latter

# Screen Shots
| Before | After |
|--------|--------|
| 
![Before](https://github.com/turnkeyca/frontend/assets/60230689/e9113715-7527-4af1-b088-c4ec126c3434)
 | ![After](https://github.com/turnkeyca/frontend/assets/60230689/78ab3b9e-6e82-4dfe-8aa3-97ff27a8de16) | 


Closes #35 
